### PR TITLE
fix: re-setup CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
+    assignees:
+      - "k1LoW"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
+    assignees:
+      - "k1LoW"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,28 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
 
       - name: Run lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0
+        with:
+          fail_level: warning
+          go_version_file: go.mod
 
       - name: Run tests
         run: make ci
 
       - name: Run octocov
-        uses: k1LoW/octocov-action@v0
+        uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -9,47 +9,58 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
-
-      - id: run-tagpr
-        name: Run tagpr
-        uses: Songmu/tagpr@v1
-
-  release:
-    needs: tagpr
-    if: needs.tagpr.outputs.tagpr-tag != ''
-    runs-on: macos-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Setup docker
-        uses: docker-practice/actions-setup-docker@master
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
-      - name: Setup
-        run: |
-          brew uninstall go@1.17
-          brew install go
-          brew install goreleaser
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
 
-      - name: Release
-        run: |
-          make release
+      - id: run-tagpr
+        name: Run tagpr
+        uses: Songmu/tagpr@9c294c8b7b1815a5f3b7c61d6ee6aa50ac25b030 # v1.8.4
+
+  assets:
+    needs: tagpr
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    runs-on: macos-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: latest
+          args: --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dockerimage:
     needs: tagpr
@@ -59,7 +70,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -71,30 +82,43 @@ jobs:
           cat $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/k1low/repin:latest
             ghcr.io/k1low/repin:${{ steps.latest_version.outputs.version }}
+            ghcr.io/k1low/repin:latest
           labels: |
             org.opencontainers.image.name=repin
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.latest_version.outputs.version }}
             org.opencontainers.image.source=https://github.com/k1LoW/repin
+          
+  release:
+    needs: [tagpr, assets, dockerimage]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Release
+        run: |
+          gh api /repos/${{ github.repository }}/releases/generate-notes -f tag_name=${{ needs.tagpr.outputs.tagpr-tag }} --jq .body | gh release edit ${{ needs.tagpr.outputs.tagpr-tag }} --repo ${{ github.repository }} --draft=false --latest --notes-file=-
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,41 @@
+version: "2"
+run:
+  timeout: 2m
+linters:
+  enable:
+    - errorlint
+    - godot
+    - gosec
+    - misspell
+    - revive
+    - funcorder
+  settings:
+    errcheck:
+      check-type-assertions: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+        - name: exported
+          disabled: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - tmpmod
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -12,9 +13,9 @@ builds:
   goarch:
     - amd64
     - arm64
-  main: ./cmd/repin/main.go
   ldflags:
     - -s -w -X github.com/k1LoW/repin.version={{.Version}} -X github.com/k1LoW/repin.commit={{.FullCommit}} -X github.com/k1LoW/repin.date={{.Date}} -X github.com/k1LoW/repin/version.Version={{.Version}}
+  main: ./cmd/repin/main.go
 -
   id: repin-darwin
   env:
@@ -24,9 +25,9 @@ builds:
   goarch:
     - amd64
     - arm64
-  main: ./cmd/repin/main.go
   ldflags:
     - -s -w -X github.com/k1LoW/repin.version={{.Version}} -X github.com/k1LoW/repin.commit={{.FullCommit}} -X github.com/k1LoW/repin.date={{.Date}} -X github.com/k1LoW/repin/version.Version={{.Version}}
+  main: ./cmd/repin/main.go
 -
   id: repin-windows
   env:
@@ -35,9 +36,9 @@ builds:
     - windows
   goarch:
     - amd64
-  main: ./cmd/repin/main.go
   ldflags:
     - -s -w -X github.com/k1LoW/repin.version={{.Version}} -X github.com/k1LoW/repin.commit={{.FullCommit}} -X github.com/k1LoW/repin.date={{.Date}} -X github.com/k1LoW/repin/version.Version={{.Version}}
+  main: ./cmd/repin/main.go
 archives:
 -
   id: repin-archive
@@ -46,31 +47,35 @@ archives:
     - goos: darwin
       format: zip
   files:
+    - LICENSE
     - CREDITS
     - README.md
     - CHANGELOG.md
--
-  id: repin-binary
-  name_template: '{{ .Binary }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-  format: binary
 checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ .Version }}-next"
 changelog:
-  skip: true
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
 nfpms:
-  - id: repin-nfpms
+  -
+    id: repin-nfpms
     file_name_template: "{{ .ProjectName }}_{{ .Version }}-1_{{ .Arch }}"
     builds:
-      - repin-linux
+    - repin-linux
     homepage: https://github.com/k1LoW/repin
     maintainer: Ken'ichiro Oyama <k1lowxb@gmail.com>
     description: repin is a tool to replace strings between keyword pair.
     license: MIT
     formats:
-      - apk
       - deb
       - rpm
     bindir: /usr/bin
     epoch: 1
+release:
+  draft: true
+  replace_existing_draft: true

--- a/.tagpr
+++ b/.tagpr
@@ -34,3 +34,4 @@
 	releaseBranch = main
 	versionFile = version/version.go
 	command = "make prerelease_for_tagpr"
+	release = draft

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1-bullseye AS builder
+FROM golang:1.24.7 AS builder
 
 WORKDIR /workdir/
 COPY . /workdir/
@@ -9,7 +9,7 @@ RUN update-ca-certificates
 
 RUN make build
 
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workdir/repin ./usr/bin

--- a/Makefile
+++ b/Makefile
@@ -29,26 +29,11 @@ build:
 	go build -ldflags="$(BUILD_LDFLAGS)" -o repin cmd/repin/main.go
 
 depsdev:
-	go install github.com/Songmu/ghch/cmd/ghch@v0.10.2
-	go install github.com/Songmu/gocredits/cmd/gocredits@v0.2.0
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.8.1
-
-prerelease:
-	git pull origin main --tag
-	go mod tidy
-	ghch -w -N ${VER}
-	gocredits . > CREDITS
-	git add CHANGELOG.md CREDITS go.mod go.sum
-	git commit -m'Bump up version number'
-	git tag ${VER}
+	go install github.com/Songmu/gocredits/cmd/gocredits@latest
 
 prerelease_for_tagpr:
 	go mod tidy
 	gocredits -w .
 	git add CHANGELOG.md CREDITS go.mod go.sum
-
-release:
-	git push origin main --tag
-	goreleaser --rm-dist
 
 .PHONY: default test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,6 @@ var (
 	keyRep      = strings.NewReplacer("\\n", "\n", "\\t", "\t")
 )
 
-// rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:          "repin [FILE]",
 	Short:        "repin is a tool to replace strings between keyword pair",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k1LoW/repin
 
-go 1.19
+go 1.24
 
 require (
 	github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-dirmap $@
+repin $@

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
-// Name for this
+// Name for this.
 const Name string = "repin"
 
-// Version for this
+// Version for this.
 var Version = "0.3.4"


### PR DESCRIPTION
This pull request introduces several improvements to the project's automation, build, and release processes, as well as updates to dependencies and configuration files. The main focus is on enhancing CI/CD workflows, updating build and linter configurations, and modernizing the Docker setup.

**CI/CD Workflow and Automation Improvements:**

* Updated GitHub Actions workflows (`ci.yml`, `tagpr.yml`) to use pinned action versions, added explicit permissions, improved Go setup, and streamlined release and Docker build steps. Also added a new release job for automated release note generation. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR15-R39) [[2]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR12-R63) [[3]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eL62-R73) [[4]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eL74-R124)

* Added `.github/dependabot.yml` to automate dependency updates for GitHub Actions and Go modules, scheduled weekly.

**Build and Release Configuration Updates:**

* Introduced `.goreleaser.yml` with version 2 schema and improved builds, archive, changelog, and release settings. Added LICENSE to archives and refined changelog filtering. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R1) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L15-R18) [[3]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L27-R30) [[4]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L38-R41) [[5]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R50-R66) [[6]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L72-R81)
* Updated `.tagpr` configuration to mark releases as drafts by default.

**Linter and Quality Tools:**

* Added `.golangci.yml` to configure and enable multiple linters, with custom rules and exclusions for improved code quality.

**Docker and Go Modernization:**

* Updated `Dockerfile` to use Go 1.24.7 and Debian trixie-slim for the runtime image, modernizing the build environment. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L12-R12)
* Updated `go.mod` to require Go 1.24.

**Miscellaneous:**

* Simplified `Makefile` by removing old prerelease and release targets, and updated dependency installation to always use the latest `gocredits`.
* Changed `scripts/entrypoint.sh` to use `repin` as the entrypoint command.
* Minor documentation and comment improvements in `version/version.go`.
* Minor code cleanup in `cmd/root.go`.